### PR TITLE
Custom labels for grammars & keys in drop-down selection menus

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -25,22 +25,16 @@
 	}
 	
 	function loadGrammarOptions(json) {
-		let select = $("grammar");
-		while (select.firstChild) {
-			select.removeChild(select.firstChild);
-		}
-		let data = JSON.parse(json);
-		for (let i = 0; i < data.length; i++) {
-			let option = ce("option");
-			option.value = data[i];
-			option.textContent = data[i];
-			select.appendChild(option);
-		}
+		loadOptionsJSON($("grammar"), json);
 		ajaxGET("backend/info.php?mode=list&grammar=" + $("grammar").value, loadKeyOptions);
 	}
 	
 	function loadKeyOptions(json) {
-		let select = $("key");
+		loadOptionsJSON($("key"), json);
+		generate();
+	}
+	
+	function loadOptionsJSON(select, json) {
 		while (select.firstChild) {
 			select.removeChild(select.firstChild);
 		}

--- a/backend.js
+++ b/backend.js
@@ -25,16 +25,7 @@
 	}
 	
 	function loadGrammarOptions(json) {
-		loadOptionsJSON($("grammar"), json);
-		ajaxGET("backend/info.php?mode=list&grammar=" + $("grammar").value, loadKeyOptions);
-	}
-	
-	function loadKeyOptions(json) {
-		loadOptionsJSON($("key"), json);
-		generate();
-	}
-	
-	function loadOptionsJSON(select, json) {
+		let select = $("grammar");
 		while (select.firstChild) {
 			select.removeChild(select.firstChild);
 		}
@@ -43,6 +34,21 @@
 			let option = ce("option");
 			option.value = data[i];
 			option.textContent = data[i];
+			select.appendChild(option);
+		}
+		ajaxGET("backend/info.php?mode=list&grammar=" + $("grammar").value, loadKeyOptions);
+	}
+	
+	function loadKeyOptions(json) {
+		let select = $("key");
+		while (select.firstChild) {
+			select.removeChild(select.firstChild);
+		}
+		let data = JSON.parse(json);
+		for (let i = 0; i < data.length; i++) {
+			let option = ce("option");
+			option.value = data[i]["key"];
+			option.textContent = data[i]["name"];
 			select.appendChild(option);
 		}
 	}

--- a/backend/grammarParser.php
+++ b/backend/grammarParser.php
@@ -10,13 +10,10 @@
 	# a grammatical structure. Associative array format:
 	#		key => array(def0, def1, def2, ...)
 	function parse_grammar($grammar) {
-		
-		$file = file_get_contents("../grammars/$grammar/language.txt");
-		$file_lines = explode("\n", $file);
-		
+		$file = parse_file($grammar, "language.txt");
 		$grammar_rules = array();
-		for ($i = 0; $i < count($file_lines); $i++) {
-			$line = explode("::=", $file_lines[$i]);
+		for ($i = 0; $i < count($file); $i++) {
+			$line = explode("::=", $file[$i]);
 			$term = trim($line[0]);
 			$definitions = explode("|", $line[1]);
 			$term_array = array();
@@ -41,6 +38,22 @@
 			}
 		}
 		return $grammar_rules;
+	}
+	
+	# parses a "display" file to find the display names for each
+	# tag in a language, etc
+	function parse_display($grammar) {
+		$file = parse_file($grammar, "display.txt");
+		$grammar_display = array();
+		for ($i = 0; $i < count($file); $i++) {
+			$line = explode("=", $file[$i]);
+			$term = trim($line[0]);
+			$display = trim($line[1]);
+			if ($display) {
+				$grammar_display[$term] = $display;
+			}
+		}
+		return $grammar_display;
 	}
 	
 	# parses a file into its constituent lines for easy addition to a

--- a/backend/info.php
+++ b/backend/info.php
@@ -33,9 +33,21 @@
 	else if ($mode === "list" && $grammar) {
 		include('grammarParser.php');
 		$grammar_rules = parse_grammar($grammar);
-		if ($grammar_rules) {	# grammar must be valid
-			$keys = array_keys($grammar_rules);
-			print(json_encode($keys));
+		$grammar_display = parse_display($grammar);
+		if ($grammar_rules && $grammar_display) { # needs definition
+			$result = array();
+			$rule_keys = array_keys($grammar_rules);
+			$display_keys = array_keys($grammar_display);
+			for ($i = 0; $i < count($display_keys); $i++) {
+				$key = $display_keys[$i];
+				if (in_array($key, $rule_keys)) {
+					$item = array();
+					$item["key"] = $key;
+					$item["name"] = $grammar_display[$key];
+					$result[] = $item;
+				}
+			}
+			print(json_encode($result));
 		}
 	}
 	

--- a/backend/info.php
+++ b/backend/info.php
@@ -53,9 +53,24 @@
 	
 	# lists all potential grammars
 	else if ($mode === "list") {
-		$files = scandir("../grammars/");
-		$files = array_slice($files, 2);
-		print(json_encode($files));
+		include('grammarParser.php');
+		$grammars = scandir("../grammars/");
+		$grammars = array_slice($grammars, 3);
+		$display = parse_display(".");
+		if ($grammars && $display) {
+			$result = array();
+			$keys = array_keys($display);
+			for ($i = 0; $i < count($keys); $i++) {
+				$key = $keys[$i];
+				if (in_array($key, $grammars)) {
+					$item = array();
+					$item["key"] = $key;
+					$item["name"] = $display[$key];
+					$result[] = $item;
+				}
+			}
+			print(json_encode($result));
+		}
 	}
 	
 } ?>

--- a/grammars/display.txt
+++ b/grammars/display.txt
@@ -1,0 +1,3 @@
+english = English
+japanese = Japanese
+math = Math

--- a/grammars/english/display.txt
+++ b/grammars/english/display.txt
@@ -1,0 +1,4 @@
+$sentence = Sentence
+$noun = Noun
+$adjective = Adjective
+$verb = Verb


### PR DESCRIPTION
**KEY: MUST SPECIFY NAMES IN display.txt FOR EACH GRAMMAR!!** Otherwise, it won't show any values or grammars at all. This is useful; it lets us reorder options and say which parts should be able to be generated at the user's whim and which should remain private.

Syntax for display.txt:
$key = Name
$key2 = Name 2
... (one per line)